### PR TITLE
Add support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
  - "2.7"
+ - "3.5"
+ - "3.6"
 script:
 - "python setup.py test"

--- a/quickcache/cache_helpers.py
+++ b/quickcache/cache_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import namedtuple
 from .logger import logger
 

--- a/quickcache/logger.py
+++ b/quickcache/logger.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 
 

--- a/quickcache/quickcache.py
+++ b/quickcache/quickcache.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import absolute_import
 from collections import namedtuple
 import functools
 

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -6,6 +6,11 @@ from inspect import isfunction
 from .logger import logger
 import six
 
+if six.PY2:
+    NUMERIC_TYPES = (int, long, float)
+else:
+    NUMERIC_TYPES = (int, float)
+
 
 class QuickCacheHelper(object):
     def __init__(self, fn, vary_on, cache, skip_arg=None, assert_function=None):
@@ -96,7 +101,7 @@ class QuickCacheHelper(object):
             return 'u' + self._hash(encoded)
         elif isinstance(value, bool):
             return 'b' + str(int(value))
-        elif isinstance(value, (int, long, float)):
+        elif isinstance(value, NUMERIC_TYPES):
             return 'n' + str(value)
         elif isinstance(value, (list, tuple)):
             return 'L' + self._hash(

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import hashlib
 import inspect
 from inspect import isfunction

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -4,6 +4,7 @@ import inspect
 from inspect import isfunction
 
 from .logger import logger
+import six
 
 
 class QuickCacheHelper(object):
@@ -31,13 +32,13 @@ class QuickCacheHelper(object):
 
         self.vary_on = vary_on
 
-        if skip_arg is None or isinstance(skip_arg, basestring) or isfunction(skip_arg):
+        if skip_arg is None or isinstance(skip_arg, six.string_types) or isfunction(skip_arg):
             self.skip_arg = skip_arg
         else:
             raise ValueError("skip_arg must be None, a string, or a function")
 
         arg_spec = inspect.getargspec(self.fn)
-        if isinstance(skip_arg, basestring) and self.skip_arg not in arg_spec.args:
+        if isinstance(skip_arg, six.string_types) and self.skip_arg not in arg_spec.args:
             raise ValueError(
                 'We cannot use "{}" as the "skip" parameter because the function {} has '
                 'no such argument'.format(self.skip_arg, self.fn.__name__)
@@ -79,7 +80,7 @@ class QuickCacheHelper(object):
         return hashlib.md5(value).hexdigest()[-length:]
 
     def _serialize_for_key(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             # Unicode and string values should generate the same key since users generally
             # intend them to mean the same thing. If a use case for differentiating
             # them presents itself add a 'lenient_strings=False' option to allow
@@ -132,7 +133,7 @@ class QuickCacheHelper(object):
     def skip(self, *args, **kwargs):
         if not self.skip_arg:
             return False
-        elif isinstance(self.skip_arg, basestring):
+        elif isinstance(self.skip_arg, six.string_types):
             callargs = inspect.getcallargs(self.fn, *args, **kwargs)
             return callargs[self.skip_arg]
         elif isfunction(self.skip_arg):

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,7 @@ setup(
     url='https://github.com/dimagi/quickcache',
     packages=['quickcache'],
     test_suite='test_quickcache',
-    install_requires=[],
+    install_requires=[
+        'six==1.11.0',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
 from setuptools import setup
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,12 @@ setup(
     install_requires=[
         'six==1.11.0',
     ],
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
 )

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import time
 
 from unittest import TestCase
@@ -181,7 +181,7 @@ class QuickcacheTest(TestCase):
             return hash(bytes)
 
         symbols = '!@#$%^&*():{}"?><.~`'
-        bytes = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09'
+        bytes = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09'
         self.assertEqual(encode(symbols), hash(symbols))
         self.assertEqual(encode(bytes), hash(bytes))
 

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import time
 
 from unittest import TestCase


### PR DESCRIPTION
I'm not sure that dropping the distinction between text and bytes is a good thing on Python 3 (or even Python 2 for that matter), but I'm not sure there's an easy way around that that would still be compatible with the way this library is used in https://github.com/dimagi/commcare-hq.

@dannyroberts cc @nickpell 