### PR TITLE
add session_function option to get_django_quickcache

### DIFF
--- a/quickcache/cache_helpers.py
+++ b/quickcache/cache_helpers.py
@@ -3,16 +3,22 @@ from collections import namedtuple
 from .logger import logger
 
 
-class CacheWithTimeout(namedtuple('CacheWithTimeout', ['cache', 'timeout'])):
+class CacheWithPresets(namedtuple('CacheWithPresets', ['cache', 'timeout', 'prefix_function'])):
+
+    def prefixed_key(self, key):
+        if self.prefix_function:
+            return self.prefix_function() + key
+        else:
+            return key
 
     def get(self, key, default=None):
-        return self.cache.get(key, default=default)
+        return self.cache.get(self.prefixed_key(key), default=default)
 
     def set(self, key, value):
-        return self.cache.set(key, value, timeout=self.timeout)
+        return self.cache.set(self.prefixed_key(key), value, timeout=self.timeout)
 
     def delete(self, key):
-        return self.cache.delete(key)
+        return self.cache.delete(self.prefixed_key(key))
 
 
 class TieredCache(object):

--- a/quickcache/cache_helpers.py
+++ b/quickcache/cache_helpers.py
@@ -1,9 +1,15 @@
 from __future__ import absolute_import
+
+import warnings
 from collections import namedtuple
 from .logger import logger
 
 
 class CacheWithPresets(namedtuple('CacheWithPresets', ['cache', 'timeout', 'prefix_function'])):
+
+    # make prefix_function optional
+    def __new__(cls, cache, timeout, prefix_function=None):
+        return super(CacheWithPresets, cls).__new__(cls, cache, timeout, prefix_function)
 
     def prefixed_key(self, key):
         if self.prefix_function:
@@ -19,6 +25,13 @@ class CacheWithPresets(namedtuple('CacheWithPresets', ['cache', 'timeout', 'pref
 
     def delete(self, key):
         return self.cache.delete(self.prefixed_key(key))
+
+
+class CacheWithTimeout(CacheWithPresets):
+    def __new__(cls, cache, timeout):
+        warnings.warn("CacheWithTimeout is deprecated. Please use CacheWithPresets instead.",
+                      DeprecationWarning)
+        return super(CacheWithTimeout, cls).__new__(cls, cache, timeout)
 
 
 class TieredCache(object):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='quickcache',
-    version='0.2.0',
+    version='0.3.0',
     description='caching has never been easier',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -8,7 +8,7 @@ import datetime
 import uuid
 
 from quickcache import get_quickcache
-from quickcache.cache_helpers import TieredCache
+from quickcache.cache_helpers import TieredCache, CacheWithPresets
 
 BUFFER = []
 
@@ -58,6 +58,18 @@ class CacheMock(LocMemCache):
             BUFFER.append('{} set'.format(self.name))
 
 
+class SessionMock(object):
+    session = ''
+
+    @classmethod
+    def get_session(cls):
+        return cls.session
+
+    @classmethod
+    def reset_session(cls):
+        cls.session = ''
+
+
 SHORT_TIME_UNIT = 0.01
 
 _local_cache = CacheMock('local', timeout=SHORT_TIME_UNIT)
@@ -66,7 +78,8 @@ _cache = TieredCache([_local_cache, _shared_cache])
 _cache_with_set = CacheMock('cache', timeout=SHORT_TIME_UNIT, silent_set=False)
 
 quickcache = get_quickcache(cache=TieredCache([
-    CacheMock('local', timeout=10),
+    CacheWithPresets(CacheMock('local', timeout=None), timeout=10,
+                     prefix_function=SessionMock.get_session),
     CacheMock('shared', timeout=5 * 60)]
 ))
 
@@ -126,6 +139,35 @@ class QuickcacheTest(TestCase):
                           # fib(3/4/5) also ask for fib(1/2/3)
                           # so three cache hits
                           'local hit', 'local hit', 'local hit'])
+
+    def test_session_prefix(self):
+        """
+        When you call the same function from a different session,
+        the shared cache will hit but the local cache will miss
+
+        The point of this feature is to make the local cache effectively last
+        the length of a "session" (i.e. a request, an async task, etc.)
+        to avoid inconsistent local caches between processes
+        """
+        @quickcache([])
+        def return_one():
+            BUFFER.append('called')
+            return 1
+
+        SessionMock.session = 'a'
+        self.addCleanup(SessionMock.reset_session)
+
+        self.assertEqual(return_one(), 1)
+        self.assertEqual(self.consume_buffer(), ['local miss', 'shared miss', 'called'])
+        self.assertEqual(return_one(), 1)
+        self.assertEqual(self.consume_buffer(), ['local hit'])
+
+        SessionMock.session = 'b'
+        self.addCleanup(SessionMock.reset_session)
+        self.assertEqual(return_one(), 1)
+        self.assertEqual(self.consume_buffer(), ['local miss', 'shared hit'])
+        self.assertEqual(return_one(), 1)
+        self.assertEqual(self.consume_buffer(), ['local hit'])
 
     def test_vary_on_attr(self):
         class Item(object):

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -8,7 +8,7 @@ import datetime
 import uuid
 
 from quickcache import get_quickcache
-from quickcache.cache_helpers import TieredCache, CacheWithPresets
+from quickcache.cache_helpers import TieredCache, CacheWithPresets, CacheWithTimeout
 
 BUFFER = []
 
@@ -80,7 +80,8 @@ _cache_with_set = CacheMock('cache', timeout=SHORT_TIME_UNIT, silent_set=False)
 quickcache = get_quickcache(cache=TieredCache([
     CacheWithPresets(CacheMock('local', timeout=None), timeout=10,
                      prefix_function=SessionMock.get_session),
-    CacheMock('shared', timeout=5 * 60)]
+    # even though CacheWithTimeout is deprecated, test it while it's still supported.
+    CacheWithTimeout(CacheMock('shared', timeout=None), timeout=5 * 60)]
 ))
 
 


### PR DESCRIPTION
When you call the same function from a different session,
the shared cache will hit but the local cache will miss

The point of this feature is to make the local cache effectively last
the length of a "session" (i.e. a request, an async task, etc.)
to avoid inconsistent local caches between processes

This implements the suggestion made here: https://github.com/dimagi/commcare-hq/pull/19382#issuecomment-365045289.

Example usage (and the original impetus for this change): https://github.com/dimagi/commcare-hq/pull/19853