### PR TITLE
Datetime serialization

### DIFF
--- a/quickcache/native_utc.py
+++ b/quickcache/native_utc.py
@@ -1,0 +1,20 @@
+from datetime import tzinfo, timedelta
+
+ZERO = timedelta(0)
+HOUR = timedelta(hours=1)
+
+
+class UTC(tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return ZERO
+
+
+utc = UTC()

--- a/quickcache/native_utc.py
+++ b/quickcache/native_utc.py
@@ -1,3 +1,6 @@
+'''
+Source code from: https://docs.python.org/2.7/library/datetime.html#tzinfo-objects
+'''
 from datetime import tzinfo, timedelta
 
 ZERO = timedelta(0)

--- a/quickcache/native_utc.py
+++ b/quickcache/native_utc.py
@@ -1,7 +1,6 @@
 from datetime import tzinfo, timedelta
 
 ZERO = timedelta(0)
-HOUR = timedelta(hours=1)
 
 
 class UTC(tzinfo):

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 import datetime
-import pytz
 import hashlib
 import inspect
 from inspect import isfunction
 from collections import namedtuple
 
 from .logger import logger
+from .native_utc import utc
 import six
 
 if six.PY2:
@@ -128,7 +128,7 @@ class QuickCacheHelper(object):
             if not value.tzinfo:
                 serialized_value = value.isoformat()
             else:
-                serialized_value = value.astimezone(pytz.UTC).isoformat()
+                serialized_value = value.astimezone(utc).isoformat()
             return 'DT{}'.format(serialized_value)
         elif value is None:
             return 'N'

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -125,9 +125,12 @@ class QuickCacheHelper(object):
             return 'S' + self._hash(
                 ','.join(sorted(map(self._serialize_for_key, value))))
         elif isinstance(value, datetime.datetime):
+            serialized_value = None
             if not value.tzinfo:
-                return value.isoformat()
-            return value.astimezone(pytz.UTC).isoformat()
+                serialized_value = value.isoformat()
+            else:
+                serialized_value = value.astimezone(pytz.UTC).isoformat()
+            return 'DT{}'.format(serialized_value)
         elif value is None:
             return 'N'
         else:

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -125,6 +125,10 @@ class QuickCacheHelper(object):
             return 'S' + self._hash(
                 ','.join(sorted(map(self._serialize_for_key, value))))
         elif isinstance(value, datetime.datetime):
+            # Cache key equality for datetimes follows python equality. Namely:
+            # - Datetimes with different timezones but representing the same point in time are serialized
+            #   the same way
+            # - Naive datetimes can't cause a cache hit for tz aware datetimes (and vice versa)
             if not value.tzinfo:
                 serialized_value = value.isoformat()
             else:

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -125,7 +125,6 @@ class QuickCacheHelper(object):
             return 'S' + self._hash(
                 ','.join(sorted(map(self._serialize_for_key, value))))
         elif isinstance(value, datetime.datetime):
-            serialized_value = None
             if not value.tzinfo:
                 serialized_value = value.isoformat()
             else:

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+import datetime
+import pytz
 import hashlib
 import inspect
 from inspect import isfunction
@@ -122,6 +124,10 @@ class QuickCacheHelper(object):
         elif isinstance(value, set):
             return 'S' + self._hash(
                 ','.join(sorted(map(self._serialize_for_key, value))))
+        elif isinstance(value, datetime.datetime):
+            if not value.tzinfo:
+                return value.isoformat()
+            return value.astimezone(pytz.UTC).isoformat()
         elif value is None:
             return 'N'
         else:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     test_suite='test_quickcache',
     install_requires=[
         'six==1.11.0',
+        'pytz==2018.3',
     ],
     classifiers=[
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     test_suite='test_quickcache',
     install_requires=[
         'six==1.11.0',
-        'pytz==2018.3',
     ],
     classifiers=[
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='quickcache',
-    version='0.3.0',
+    version='0.4.0',
     description='caching has never been easier',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -312,7 +312,6 @@ class QuickcacheTest(TestCase):
 
         dt_naive = datetime.datetime(2018, 3, 30)
         # Test naive datetimes
-        self.assertNotEqual(dt, dt_naive)
         self.assertEqual(by_datetime(dt), 'VALUE')
         self.assertEqual(self.consume_buffer(), ['cache miss', 'called', 'cache set'])
         self.assertEqual(by_datetime(dt_naive), 'VALUE')

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -10,6 +10,7 @@ import uuid
 
 from quickcache import get_quickcache
 from quickcache.cache_helpers import TieredCache, CacheWithPresets, CacheWithTimeout
+from quickcache.native_utc import utc
 
 BUFFER = []
 
@@ -289,7 +290,7 @@ class QuickcacheTest(TestCase):
             BUFFER.append('called')
             return 'VALUE'
 
-        dt = datetime.datetime(2018, 3, 30, tzinfo=pytz.UTC)
+        dt = datetime.datetime(2018, 3, 30, tzinfo=utc)
         # Basic datetime serialization
         self.assertEqual(by_datetime(dt), 'VALUE')
         self.assertEqual(self.consume_buffer(), ['cache miss', 'called', 'cache set'])

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -311,7 +311,7 @@ class QuickcacheTest(TestCase):
         time.sleep(SHORT_TIME_UNIT)
 
         dt_naive = datetime.datetime(2018, 3, 30)
-        # Test naive timezones
+        # Test naive datetimes
         self.assertNotEqual(dt, dt_naive)
         self.assertEqual(by_datetime(dt), 'VALUE')
         self.assertEqual(self.consume_buffer(), ['cache miss', 'called', 'cache set'])

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 import time
-import pytz
 
 from unittest import TestCase
 import datetime
@@ -70,6 +69,17 @@ class SessionMock(object):
     @classmethod
     def reset_session(cls):
         cls.session = ''
+
+
+class CustomTZ(datetime.tzinfo):
+    def utcoffset(self, dt):
+        return datetime.timedelta(hours=3)
+
+    def tzname(self, dt):
+        return "CustomTZ"
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
 
 
 SHORT_TIME_UNIT = 0.01
@@ -300,12 +310,12 @@ class QuickcacheTest(TestCase):
         # let the local cache expire
         time.sleep(SHORT_TIME_UNIT)
 
-        dt_pst = dt.astimezone(pytz.timezone('US/Pacific'))
+        dt_custom = dt.astimezone(CustomTZ())
         # Test different timezones. Should produce a cache hit
-        self.assertEqual(dt, dt_pst)
+        self.assertEqual(dt, dt_custom)
         self.assertEqual(by_datetime(dt), 'VALUE')
         self.assertEqual(self.consume_buffer(), ['cache miss', 'called', 'cache set'])
-        self.assertEqual(by_datetime(dt_pst), 'VALUE')
+        self.assertEqual(by_datetime(dt_custom), 'VALUE')
         self.assertEqual(self.consume_buffer(), ['cache hit'])
 
         # let the local cache expire


### PR DESCRIPTION
@dannyroberts @millerdev did a quick cut of what it could look like.

1. Datetimes with different timezones but representing the same point in time are serialized the same way
2. Naive datetimes can't cause a cache hit for tz aware datetimes (and vice versa)