### PR TITLE
allow custom prefix_function to raise ForceSkipCache

### DIFF
--- a/quickcache/__init__.py
+++ b/quickcache/__init__.py
@@ -1,8 +1,10 @@
 from .quickcache import get_quickcache
 from .quickcache_helper import QuickCacheHelper
+from .cache_helpers import ForceSkipCache
 
 
 __all__ = [
     'get_quickcache',
     'QuickCacheHelper',
+    'ForceSkipCache'
 ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='quickcache',
-    version='0.5.0a1',
+    version='0.5.0',
     description='caching has never been easier',
     author='Dimagi',
     author_email='dev@dimagi.com',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='quickcache',
-    version='0.4.0',
+    version='0.5.0a1',
     description='caching has never been easier',
     author='Dimagi',
     author_email='dev@dimagi.com',


### PR DESCRIPTION
When using `prefix_function` to scope by "session" (i.e. a request / particular background task), using a fallback "not in a session" value causes problems, especially in a testing setting, where it's common for the main testing thread to not be in a "session", but maybe a fake background task is in a session. If you clear the function in the fake background task session, then in the main testing thread's cache won't get cleared, and when it goes to test whether a particular (cached) value is correctly set, it'll get a stale previous answer rather than the updated one.

This change allows `prefix_function` to raise `ForceSkipCache`, which will skip that particular cache. This is useful in the context of a tiered cache with a "local", session-scoped cache and a "shared", globally-scoped cache.

Merge checklist:
- [x] https://github.com/dimagi/commcare-hq/pull/19853 passes
- [x] promote release to 0.5.0