### PR TITLE
Remove version dependency on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=['quickcache'],
     test_suite='test_quickcache',
     install_requires=[
-        'six==1.11.0',
+        'six',
     ],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
So that it doesn't restrict downstream dependencies