### PR TITLE
lazy string evaluation for logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: xenial
 language: python
 python:
- - 2.7
- - 3.5
- - 3.6
  - 3.7
+ - 3.8
+ - 3.9
+ - "3.10"
 script:
 - "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 dist: xenial
 language: python
 python:
- - 3.7
  - 3.8
  - 3.9
- - "3.10"
 script:
 - "python setup.py test"

--- a/quickcache/__init__.py
+++ b/quickcache/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from .quickcache import get_quickcache
 from .quickcache_helper import QuickCacheHelper
 from .cache_helpers import ForceSkipCache

--- a/quickcache/cache_helpers.py
+++ b/quickcache/cache_helpers.py
@@ -45,7 +45,7 @@ class CacheWithTimeout(CacheWithPresets):
         return super(CacheWithTimeout, cls).__new__(cls, cache, timeout)
 
 
-class TieredCache(object):
+class TieredCache:
     """
     Tries a number of caches in increasing order.
     Caches should be ordered with faster, more local caches at the beginning

--- a/quickcache/cache_helpers.py
+++ b/quickcache/cache_helpers.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-from __future__ import unicode_literals
 import warnings
 from collections import namedtuple
 from .logger import logger

--- a/quickcache/cache_helpers.py
+++ b/quickcache/cache_helpers.py
@@ -66,9 +66,8 @@ class TieredCache(object):
             if content is not Ellipsis:
                 for missed_cache in missed:
                     missed_cache.set(key, content)
-                logger.debug('missed caches: {}'.format([c.__class__.__name__
-                                                         for c in missed]))
-                logger.debug('hit cache: {}'.format(cache.__class__.__name__))
+                logger.debug('missed caches: %s', [c.__class__.__name__ for c in missed])
+                logger.debug('hit cache: %s', cache.__class__.__name__)
                 return content
             else:
                 missed.append(cache)

--- a/quickcache/django_quickcache.py
+++ b/quickcache/django_quickcache.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from collections import namedtuple
 
 from django.core.cache import caches

--- a/quickcache/logger.py
+++ b/quickcache/logger.py
@@ -6,4 +6,4 @@ logger = logging.getLogger('quickcache')
 
 def assert_function(assertion, message):
     if assertion:
-        logger.warn(message)
+        logger.warning(message)

--- a/quickcache/logger.py
+++ b/quickcache/logger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import logging
 
 

--- a/quickcache/native_utc.py
+++ b/quickcache/native_utc.py
@@ -1,8 +1,6 @@
 '''
 Source code from: https://docs.python.org/2.7/library/datetime.html#tzinfo-objects
 '''
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from datetime import tzinfo, timedelta
 
 ZERO = timedelta(0)

--- a/quickcache/quickcache.py
+++ b/quickcache/quickcache.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from collections import namedtuple
 import functools
 

--- a/quickcache/quickcache.py
+++ b/quickcache/quickcache.py
@@ -6,7 +6,7 @@ from .logger import assert_function
 from .quickcache_helper import QuickCacheHelper
 
 
-class ConfigMixin(object):
+class ConfigMixin:
     def but_with(self, **defaults):
         return self._replace(**defaults)
 

--- a/quickcache/quickcache.py
+++ b/quickcache/quickcache.py
@@ -24,7 +24,7 @@ class ConfigMixin(object):
         if missing_values:
             raise ValueError(
                 'the quickcache decorator still needs values '
-                'for the following parameters: {}'.format(missing_values))
+                f'for the following parameters: {missing_values}')
 
         return self.call()
 

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -26,8 +26,8 @@ class QuickCacheHelper(object):
             for arg, attrs in vary_on:
                 if arg not in arg_names:
                     raise ValueError(
-                        'We cannot vary on "{}" because the function {} has '
-                        'no such argument'.format(arg, self.fn.__name__)
+                        f'We cannot vary on "{arg}" because the function {self.fn.__name__} has '
+                        'no such argument'
                     )
 
         self.encoding_assert = assert_function
@@ -42,16 +42,16 @@ class QuickCacheHelper(object):
         arg_spec = getfullargspec(self.fn)
         if isinstance(skip_arg, str) and self.skip_arg not in arg_spec.args:
             raise ValueError(
-                'We cannot use "{}" as the "skip" parameter because the function {} has '
-                'no such argument'.format(self.skip_arg, self.fn.__name__)
+                f'We cannot use "{self.skip_arg}" as the "skip" parameter because the function {self.fn.__name__} has '
+                'no such argument'
             )
 
         if not isfunction(self.vary_on):
             for arg, attrs in self.vary_on:
                 if arg == self.skip_arg:
                     raise ValueError(
-                        'You cannot use the "{}" argument as a vary on parameter and '
-                        'as the "skip cache" parameter in the function: {}'.format(arg, self.fn.__name__)
+                        f'You cannot use the "{arg}" argument as a vary on parameter and '
+                        f'as the "skip cache" parameter in the function: {self.fn.__name__}'
                     )
 
     def call(self, *args, **kwargs):
@@ -119,7 +119,7 @@ class QuickCacheHelper(object):
             return 'S' + self._hash(
                 ','.join(sorted(map(self._serialize_for_key, value))))
         elif isinstance(value, uuid.UUID):
-            return 'U{}'.format(value)
+            return f'U{value}'
         elif isinstance(value, datetime.datetime):
             # Cache key equality for datetimes follows python equality. Namely:
             # - Datetimes with different timezones but representing the same point in time are serialized
@@ -129,11 +129,11 @@ class QuickCacheHelper(object):
                 serialized_value = value.isoformat()
             else:
                 serialized_value = value.astimezone(utc).isoformat()
-            return 'DT{}'.format(serialized_value)
+            return f'DT{serialized_value}'
         elif value is None:
             return 'N'
         else:
-            raise ValueError('Bad type "{}": {}'.format(type(value), value))
+            raise ValueError(f'Bad type "{type(value)}": {value}')
 
     def get_cache_key(self, *args, **kwargs):
         callargs = inspect.getcallargs(self.fn, *args, **kwargs)
@@ -150,7 +150,7 @@ class QuickCacheHelper(object):
                                for value in values)
         if len(args_string) > 150:
             args_string = 'H' + self._hash(args_string)
-        return 'quickcache.{}/{}'.format(self.prefix, args_string)
+        return f'quickcache.{self.prefix}/{args_string}'
 
     def skip(self, *args, **kwargs):
         if not self.skip_arg:

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -55,12 +55,12 @@ class QuickCacheHelper(object):
                     )
 
     def call(self, *args, **kwargs):
-        logger.debug('checking caches for {}'.format(self.fn.__name__))
+        logger.debug('checking caches for %s', self.fn.__name__)
         key = self.get_cache_key(*args, **kwargs)
         logger.debug(key)
         content = self.cache.get(key, default=Ellipsis)
         if content is Ellipsis:
-            logger.debug('cache miss, calling {}'.format(self.fn.__name__))
+            logger.debug('cache miss, calling %s', self.fn.__name__)
             content = self.fn(*args, **kwargs)
             self.cache.set(key, content)
         return content

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -9,7 +9,7 @@ from .logger import logger
 from .native_utc import utc
 
 
-class QuickCacheHelper(object):
+class QuickCacheHelper:
     def __init__(self, fn, vary_on, cache, skip_arg=None, assert_function=None):
 
         self.fn = fn

--- a/quickcache/quickcache_helper.py
+++ b/quickcache/quickcache_helper.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import datetime
 import uuid
 import hashlib

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,13 @@ setup(
     url='https://github.com/dimagi/quickcache',
     packages=['quickcache'],
     test_suite='test_quickcache',
-    install_requires=[
-        'six',
-    ],
+    install_requires=[],
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from setuptools import setup
 
 setup(

--- a/test_quickcache.py
+++ b/test_quickcache.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 import time
 
 from unittest import TestCase


### PR DESCRIPTION
hello friends. originally i was just looking to change the debug logging to use lazy string interpolation, but got a bit carried away when i ran pylint. i think i only applied the least controversial of python 3 items.

commits should be fairly clean if you want to go 🐡 / 🐡 

lazy logging warning: https://pylint.pycqa.org/en/latest/messages/warning/logging-not-lazy.html

3.8 and 3.9 tests passed. appears that 3.10 does not exist on travis (at least with xenial?) and 3.7 has a strange error that almost looks internal to their python setup?
