### PR TITLE
Run tests against python 3.10 as well

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: quickcache tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run tests
+      run: |
+        python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: python
 python:
  - 3.8
  - 3.9
+ - '3.10'
 script:
 - "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: xenial
-language: python
-python:
- - 3.8
- - 3.9
- - '3.10'
-script:
-- "python setup.py test"


### PR DESCRIPTION
The test failure in https://github.com/dimagi/quickcache/pull/22 on 3.10 looked possibly ephemeral, so trying here again.